### PR TITLE
Fix online summary statistics being calculated after sorting

### DIFF
--- a/install
+++ b/install
@@ -32,22 +32,22 @@ usage() {
     echo "  --dry-run,-n            Don't actually install the tools"
     echo "  --remove,-r             Uninstall the csvizmo tools"
     echo "  --prefix,-p <PREFIX>    The installation prefix. By default, tries paths in the following order:"
-    echo "                            1. \$CARGO_HOME, if set"
-    echo "                            2. ~/.cargo, if present"
-    echo "                            3. ~/.local/bin, if in the users \$PATH"
-    echo "                            4. ~/bin, if in the users \$PATH"
+    echo "                            1. ~/.local/bin/, if in the users \$PATH"
+    echo "                            2. ~/bin/, if in the users \$PATH"
+    echo "                            3. \$CARGO_HOME, if set"
+    echo "                            4. ~/.cargo/bin/, if present"
 }
 
 default_prefix() {
     local prefix=""
-    if [[ -n "${CARGO_HOME+x}" ]]; then
-        prefix="$CARGO_HOME"
-    elif [[ -d ~/.cargo ]]; then
-        prefix="$HOME/.cargo"
-    elif [[ ":$PATH:" == *":$HOME/.local/bin:"* ]]; then
+    if [[ ":$PATH:" == *":$HOME/.local/bin:"* ]]; then
         prefix="$HOME/.local"
     elif [[ ":$PATH:" == *":$HOME/bin:"* ]]; then
         prefix="$HOME/bin"
+    elif [[ -n "${CARGO_HOME+x}" ]]; then
+        prefix="$CARGO_HOME"
+    elif [[ -d ~/.cargo ]]; then
+        prefix="$HOME/.cargo"
     fi
 
     echo "$prefix"

--- a/src/bin/csvdelta.rs
+++ b/src/bin/csvdelta.rs
@@ -151,7 +151,7 @@ fn main() -> eyre::Result<()> {
         // be just to read the input file twice, which for very very large files, might be better?
         let records: Vec<_> = records.collect();
         let values = records.iter().flat_map(|(_rec, maybe_value)| maybe_value);
-        let stats = OnlineStats::from_unsorted_iter(values);
+        let stats = OnlineStats::from_unsorted_iter(values, None, None);
 
         let records = map_column_records(records.into_iter(), |maybe_value| {
             maybe_value.map(|v| v - stats.mean).ok()

--- a/src/bin/csvstats.rs
+++ b/src/bin/csvstats.rs
@@ -120,7 +120,7 @@ fn main() -> eyre::Result<()> {
 
     let mut all_stats = Vec::new();
     for (colname, col_data) in args.column.iter().zip(&mut data) {
-        let stats = OnlineStats::from_unsorted(col_data, args.min, args.max);
+        let stats = OnlineStats::from_unsorted_mut(col_data, args.min, args.max);
 
         println!("Stats for column {colname:?}:");
         println!("{stats}");

--- a/tests/test_csvstats.rs
+++ b/tests/test_csvstats.rs
@@ -41,9 +41,9 @@ Stats for column \"rolls-session-1\":
     median: 10
     Q3: 13
     min: 2 at index: 0
-    max: 20 at index: 23
-    mean: 9.791666666666668
-    stddev: 6.476315746532907
+    max: 20 at index: 4
+    mean: 9.791666666666664
+    stddev: 6.93178623865251
 
 Stats for column \"rolls-session-2\":
     count: 21
@@ -51,10 +51,10 @@ Stats for column \"rolls-session-2\":
     Q1: 5
     median: 8
     Q3: 14
-    min: 2 at index: 0
-    max: 18 at index: 19
-    mean: 9.571428571428571
-    stddev: 5.401964631566671\n\n\
+    min: 2 at index: 5
+    max: 18 at index: 14
+    mean: 9.571428571428573
+    stddev: 5.803823252952202\n\n\
     ";
 
     let mut cmd = csvstats();


### PR DESCRIPTION
The min and max indices were incorrect. After sorting, they were the LHS and RHS endpoints, rather than the indices in the original dataset.

I'm unsure how or why this changed the stddev calculation though.

Closes #33.