### PR TITLE
Allow handling already reconstructed transport sessions in can2k and canstruct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csvizmo"
-version = "0.3.0"
+version = "0.3.1"
 autotests = false
 edition = "2024"
 license = "MIT"

--- a/src/can/fastpacket.rs
+++ b/src/can/fastpacket.rs
@@ -1,4 +1,4 @@
-use crate::can::{CanFrame, CanMessage, Session};
+use crate::can::{CanMessage, Session};
 
 /// NMEA 2000 Fast Packet [Session]
 ///
@@ -26,19 +26,19 @@ pub struct FastPacketSession {
 }
 
 /// Private impl just for Fast Packet
-impl CanFrame {
+impl CanMessage {
     /// The index of this frame within this session
     #[inline]
     #[must_use]
     fn frame_counter(&self) -> u8 {
-        self.data()[0] & 0x0F
+        self.data[0] & 0x0F
     }
 
     /// Identifies a group of frames that belong together in the fast packet session
     #[inline]
     #[must_use]
     fn group_id(&self) -> u8 {
-        self.data()[0] >> 4
+        self.data[0] >> 4
     }
 
     #[inline]
@@ -51,27 +51,27 @@ impl CanFrame {
     #[must_use]
     fn session_data_length(&self) -> usize {
         debug_assert!(self.is_first_frame());
-        self.data()[1] as usize
+        self.data[1] as usize
     }
 
     #[inline]
     #[must_use]
     fn session_data(&self) -> &[u8] {
         if self.is_first_frame() {
-            &self.data()[2..]
+            &self.data[2..]
         } else {
-            &self.data()[1..]
+            &self.data[1..]
         }
     }
 }
 
 impl Session for FastPacketSession {
-    fn accepts_frame(frame: &CanFrame) -> bool {
+    fn accepts_frame(frame: &CanMessage) -> bool {
         // GNSS Position Data is the only Fast Packet message type I care about for now
-        frame.pgn() == 0x1F805
+        frame.pgn == 0x1F805
     }
 
-    fn handle_frame(&mut self, frame: CanFrame) -> eyre::Result<Option<CanMessage>> {
+    fn handle_frame(&mut self, frame: CanMessage) -> eyre::Result<Option<CanMessage>> {
         if frame.is_first_frame() {
             self.handle_first_frame(frame)?;
         } else {
@@ -106,7 +106,7 @@ impl FastPacketSession {
         }
     }
 
-    fn handle_first_frame(&mut self, frame: CanFrame) -> eyre::Result<()> {
+    fn handle_first_frame(&mut self, frame: CanMessage) -> eyre::Result<()> {
         self.session_data_length = frame.session_data_length();
         self.session_group_id = frame.group_id();
         self.current_frame_counter = frame.frame_counter();
@@ -126,7 +126,7 @@ impl FastPacketSession {
         Ok(())
     }
 
-    fn handle_following_frame(&mut self, frame: CanFrame) -> eyre::Result<()> {
+    fn handle_following_frame(&mut self, frame: CanMessage) -> eyre::Result<()> {
         let ctr = frame.frame_counter();
         let seq = self.session_group_id;
         let exp = self.current_frame_counter + 1;
@@ -160,51 +160,42 @@ impl FastPacketSession {
 mod tests {
     use super::*;
 
-    fn fast_packet_fixture() -> ([CanFrame; 4], CanMessage) {
+    fn fast_packet_fixture() -> ([CanMessage; 4], CanMessage) {
         let frames = [
-            CanFrame::new(
+            CanMessage::new(
                 0.0,
                 "can0".to_string(),
                 0x1F805FE,
-                8,
-                [0xE0, 0x1A, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06],
+                vec![0xE0, 0x1A, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06],
             ),
-            CanFrame::new(
+            CanMessage::new(
                 0.0,
                 "can0".to_string(),
                 0x1F805FE,
-                8,
-                [0xE1, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D],
+                vec![0xE1, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D],
             ),
-            CanFrame::new(
+            CanMessage::new(
                 0.0,
                 "can0".to_string(),
                 0x1F805FE,
-                8,
-                [0xE2, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14],
+                vec![0xE2, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14],
             ),
-            CanFrame::new(
+            CanMessage::new(
                 0.0,
                 "can0".to_string(),
                 0x1F805FE,
-                8,
-                [0xE3, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0xFF],
+                vec![0xE3, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0xFF],
             ),
         ];
-        let msg = CanMessage {
-            timestamp: 0.0,
-            interface: "can0".to_string(),
-            canid: 0x1F805FE,
-            priority: 0,
-            pgn: 0x1F805,
-            src: 0xFE,
-            dst: 0xFF,
-            dlc: 0x1A,
-            data: vec![
+        let msg = CanMessage::new(
+            0.0,
+            "can0".to_string(),
+            0x1F805FE,
+            vec![
                 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E,
                 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A,
             ],
-        };
+        );
         (frames, msg)
     }
 

--- a/src/can/fastpacket.rs
+++ b/src/can/fastpacket.rs
@@ -106,7 +106,7 @@ impl FastPacketSession {
         }
     }
 
-    fn handle_first_frame(&mut self, frame: CanMessage) -> eyre::Result<()> {
+    fn handle_first_frame(&mut self, mut frame: CanMessage) -> eyre::Result<()> {
         self.session_data_length = frame.session_data_length();
         self.session_group_id = frame.group_id();
         self.current_frame_counter = frame.frame_counter();
@@ -118,10 +118,9 @@ impl FastPacketSession {
             data.len(),
             self.session_data_length,
         );
-        let mut msg: CanMessage = frame.into();
-        msg.dlc = self.session_data_length;
-        msg.data = data;
-        self.message = Some(msg);
+        frame.dlc = self.session_data_length;
+        frame.data = data;
+        self.message = Some(frame);
 
         Ok(())
     }

--- a/src/can/frame.rs
+++ b/src/can/frame.rs
@@ -3,17 +3,6 @@ use std::io::Write;
 use serde::ser::SerializeStruct;
 
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct CanFrame {
-    pub timestamp: f64,
-    pub interface: String,
-    pub canid: u32,
-    pub dlc: usize,
-
-    data: [u8; 8],
-}
-
-/// [CanFrame]s are restricted to 8-bytes, [CanMessage]s are arbitrarily sized
-#[derive(Clone, Debug, Default, PartialEq)]
 pub struct CanMessage {
     pub timestamp: f64,
     pub interface: String,
@@ -24,25 +13,6 @@ pub struct CanMessage {
     pub dst: u8,
     pub dlc: usize,
     pub data: Vec<u8>,
-}
-
-impl From<CanFrame> for CanMessage {
-    fn from(frame: CanFrame) -> CanMessage {
-        let mut data: Vec<u8> = frame.data.into();
-        data.truncate(frame.dlc);
-
-        CanMessage {
-            priority: frame.priority(),
-            pgn: frame.pgn(),
-            src: frame.src(),
-            dst: frame.dst(),
-            canid: frame.canid,
-            dlc: frame.dlc,
-            timestamp: frame.timestamp,
-            interface: frame.interface,
-            data,
-        }
-    }
 }
 
 impl CanMessage {
@@ -132,79 +102,6 @@ fn pgn(canid: u32) -> u32 {
     }
 }
 
-impl CanFrame {
-    pub fn write<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        writeln!(
-            writer,
-            "({:.6}) {} {}#{}",
-            self.timestamp,
-            self.interface,
-            hex::encode_upper(self.canid.to_be_bytes()),
-            hex::encode_upper(self.data())
-        )
-    }
-}
-
-impl CanFrame {
-    pub fn new(timestamp: f64, interface: String, canid: u32, dlc: usize, data: [u8; 8]) -> Self {
-        Self {
-            timestamp,
-            interface,
-            canid,
-            dlc,
-            data,
-        }
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn data(&self) -> &[u8] {
-        &self.data[..self.dlc]
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn dst(&self) -> u8 {
-        dst(self.canid)
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn src(&self) -> u8 {
-        src(self.canid)
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn priority(&self) -> u8 {
-        priority(self.canid)
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn is_point_to_point(&self) -> bool {
-        is_point_to_point(self.canid)
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn pdu_format(&self) -> u32 {
-        pdu_format(self.canid)
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn pdu_specific(&self) -> u32 {
-        pdu_specific(self.canid)
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn pgn(&self) -> u32 {
-        pgn(self.canid)
-    }
-}
-
 impl serde::Serialize for CanMessage {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut state = serializer.serialize_struct("CanMessage", 9)?;
@@ -221,69 +118,38 @@ impl serde::Serialize for CanMessage {
     }
 }
 
-impl serde::Serialize for CanFrame {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut state = serializer.serialize_struct("CanFrame", 9)?;
-        state.serialize_field("timestamp", &self.timestamp)?;
-        state.serialize_field("interface", &self.interface)?;
-        state.serialize_field("canid", &format!("{:#X}", self.canid))?;
-        state.serialize_field("dlc", &self.dlc)?;
-        state.serialize_field("priority", &self.priority())?;
-        state.serialize_field("src", &format!("{:#X}", self.src()))?;
-        state.serialize_field("dst", &format!("{:#X}", self.dst()))?;
-        state.serialize_field("pgn", &format!("{:#X}", self.pgn()))?;
-        state.serialize_field("data", &hex::encode_upper(self.data()))?;
-        state.end()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_canid_parsing() {
-        let frame = CanFrame {
-            canid: 0x0CAC1C13,
-            ..Default::default()
-        };
-        assert_eq!(frame.pgn(), 0xAC00);
-        assert_eq!(frame.src(), 0x13);
-        assert_eq!(frame.dst(), 0x1C);
+        let canid = 0x0CAC1C13;
+        assert_eq!(pgn(canid), 0xAC00);
+        assert_eq!(src(canid), 0x13);
+        assert_eq!(dst(canid), 0x1C);
 
-        let frame = CanFrame {
-            canid: 0x18FF3F13,
-            ..Default::default()
-        };
-        assert_eq!(frame.pgn(), 0xFF3F);
-        assert_eq!(frame.src(), 0x13);
-        assert_eq!(frame.dst(), 0xFF);
+        let canid = 0x18FF3F13;
+        assert_eq!(pgn(canid), 0xFF3F);
+        assert_eq!(src(canid), 0x13);
+        assert_eq!(dst(canid), 0xFF);
 
-        let frame = CanFrame {
-            canid: 0x18EF1CF5,
-            ..Default::default()
-        };
-        assert_eq!(frame.priority(), 0x6);
-        assert_eq!(frame.pgn(), 0xEF00);
-        assert_eq!(frame.src(), 0xF5);
-        assert_eq!(frame.dst(), 0x1C);
+        let canid = 0x18EF1CF5;
+        assert_eq!(priority(canid), 0x6);
+        assert_eq!(pgn(canid), 0xEF00);
+        assert_eq!(src(canid), 0xF5);
+        assert_eq!(dst(canid), 0x1C);
 
-        let frame = CanFrame {
-            canid: 0x09F8051C,
-            ..Default::default()
-        };
-        assert_eq!(frame.priority(), 0x2);
-        assert_eq!(frame.pgn(), 0x1F805); // has the data page bit set
-        assert_eq!(frame.src(), 0x1C);
-        assert_eq!(frame.dst(), 0xFF);
+        let canid = 0x09F8051C;
+        assert_eq!(priority(canid), 0x2);
+        assert_eq!(pgn(canid), 0x1F805); // has the data page bit set
+        assert_eq!(src(canid), 0x1C);
+        assert_eq!(dst(canid), 0xFF);
 
-        let frame = CanFrame {
-            canid: 0x18EEFF1C,
-            ..Default::default()
-        };
-        assert_eq!(frame.priority(), 0x6);
-        assert_eq!(frame.pgn(), 0xEE00);
-        assert_eq!(frame.src(), 0x1C);
-        assert_eq!(frame.dst(), 0xFF);
+        let canid = 0x18EEFF1C;
+        assert_eq!(priority(canid), 0x6);
+        assert_eq!(pgn(canid), 0xEE00);
+        assert_eq!(src(canid), 0x1C);
+        assert_eq!(dst(canid), 0xFF);
     }
 }

--- a/src/can/mod.rs
+++ b/src/can/mod.rs
@@ -7,7 +7,7 @@ mod tp;
 
 pub use candump::{CandumpFormat, CandumpParser, parse_candump};
 pub use fastpacket::FastPacketSession;
-pub use frame::{CanFrame, CanMessage};
+pub use frame::CanMessage;
 pub use nmea2000::{GpsData, GpsDataWkt, N2kParser, parse_n2k_gps};
 pub use session::{Session, SessionManager, reconstruct_transport_sessions};
 pub use tp::Iso11783TransportProtocolSession;

--- a/src/can/session.rs
+++ b/src/can/session.rs
@@ -46,7 +46,7 @@ impl Session for IdentitySession {
     }
 
     fn handle_frame(&mut self, frame: CanMessage) -> eyre::Result<Option<CanMessage>> {
-        Ok(Some(frame.into()))
+        Ok(Some(frame))
     }
 }
 

--- a/src/can/session.rs
+++ b/src/can/session.rs
@@ -1,23 +1,23 @@
 use std::collections::HashMap;
 
-use crate::can::{CanFrame, CanMessage, FastPacketSession, Iso11783TransportProtocolSession};
+use crate::can::{CanMessage, FastPacketSession, Iso11783TransportProtocolSession};
 
 /// A transport layer session
 ///
-/// A [Session] is all about adapting possibly multiple [CanFrame]s into one [CanMessage]. That is,
+/// A [Session] is all about adapting possibly multiple frames into one [CanMessage]. That is,
 /// it's about reconstructing larger messages that have been broken across multiple frames.
 pub trait Session {
-    /// Determine if the given [CanFrame] has this [Session] type
-    fn accepts_frame(frame: &CanFrame) -> bool;
+    /// Determine if the given [CanMessage] has this [Session] type
+    fn accepts_frame(frame: &CanMessage) -> bool;
 
-    /// Get the session ID for the given [CanFrame], assuming that the frame is of this [Session]s
+    /// Get the session ID for the given [CanMessage], assuming that the frame is of this [Session]s
     /// type.
     ///
     /// This ID, specifies which particular instance of this [Session] type the given frame belongs
     /// to.
-    fn session_id(frame: &CanFrame) -> u32 {
-        let src = frame.src() as u32;
-        let dst = frame.dst() as u32;
+    fn session_id(frame: &CanMessage) -> u32 {
+        let src = frame.src as u32;
+        let dst = frame.dst as u32;
 
         // It's okay to have two sessions of the same type concurrently sending ecu1->ecu2 and
         // ecu2->ecu1
@@ -32,28 +32,28 @@ pub trait Session {
     ///
     /// [Session]s require in-order frames, and will happily explode in your face if given
     /// out-of-order messages.
-    fn handle_frame(&mut self, frame: CanFrame) -> eyre::Result<Option<CanMessage>>;
+    fn handle_frame(&mut self, frame: CanMessage) -> eyre::Result<Option<CanMessage>>;
 }
 
-/// Pass through [CanFrame]s unchanged into [CanMessage]s
+/// Pass through [CanMessage]s unchanged into [CanMessage]s
 ///
-/// Most [CanFrame]s are actually complete [CanMessage]s, and don't need to be reconstructed.
+/// Most [CanMessage]s are actually complete [CanMessage]s, and don't need to be reconstructed.
 pub struct IdentitySession;
 
 impl Session for IdentitySession {
-    fn accepts_frame(_: &CanFrame) -> bool {
+    fn accepts_frame(_: &CanMessage) -> bool {
         true
     }
 
-    fn handle_frame(&mut self, frame: CanFrame) -> eyre::Result<Option<CanMessage>> {
+    fn handle_frame(&mut self, frame: CanMessage) -> eyre::Result<Option<CanMessage>> {
         Ok(Some(frame.into()))
     }
 }
 
 /// Reconstruct known transport layer protocols into [CanMessage]s
 ///
-/// Unknown [CanFrame]s are passed through with the assumption they don't need to be reconstructed.
-pub fn reconstruct_transport_sessions<I: Iterator<Item = CanFrame>>(
+/// Unknown [CanMessage]s are passed through with the assumption they don't need to be reconstructed.
+pub fn reconstruct_transport_sessions<I: Iterator<Item = CanMessage>>(
     frames: I,
 ) -> SessionManager<I> {
     SessionManager {
@@ -64,7 +64,7 @@ pub fn reconstruct_transport_sessions<I: Iterator<Item = CanFrame>>(
     }
 }
 
-pub struct SessionManager<I: Iterator<Item = CanFrame>> {
+pub struct SessionManager<I: Iterator<Item = CanMessage>> {
     frames: I,
 
     identity: IdentitySession,
@@ -72,20 +72,25 @@ pub struct SessionManager<I: Iterator<Item = CanFrame>> {
     transport_protocol: HashMap<u32, (Iso11783TransportProtocolSession, tracing::Span)>,
 }
 
-impl<I: Iterator<Item = CanFrame>> Iterator for SessionManager<I> {
+impl<I: Iterator<Item = CanMessage>> Iterator for SessionManager<I> {
     // TODO: Maybe if this fails to reconstruct a session, still pass the individual frames
     // through?
     type Item = eyre::Result<CanMessage>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let frame = self.frames.next()?;
+        // Assume that if we've parsed more than 8 bytes, it's already been reconstructed, and we
+        // can just pass it through.
+        if frame.data.len() > 8 {
+            return Some(Ok(frame));
+        }
 
         if FastPacketSession::accepts_frame(&frame) {
             let session_id = FastPacketSession::session_id(&frame);
             let (mut session, span) = self.fast_packet.remove(&session_id).unwrap_or_else(|| {
                 (
                     FastPacketSession::new(),
-                    tracing::debug_span!("FP", src = frame.src(), dst = frame.dst()),
+                    tracing::debug_span!("FP", src = frame.src, dst = frame.dst),
                 )
             });
 
@@ -116,7 +121,7 @@ impl<I: Iterator<Item = CanFrame>> Iterator for SessionManager<I> {
                             // Assume that the first frame to cause a session to get created is
                             // sent from the session sender (that's not actually guaranteed if the
                             // candump was interrupted, or messages were dropped)
-                            tracing::debug_span!("TP", src = frame.src(), dst = frame.dst()),
+                            tracing::debug_span!("TP", src = frame.src, dst = frame.dst),
                         )
                     });
 
@@ -151,7 +156,7 @@ impl<I: Iterator<Item = CanFrame>> Iterator for SessionManager<I> {
     }
 }
 
-impl<I: Iterator<Item = CanFrame>> Drop for SessionManager<I> {
+impl<I: Iterator<Item = CanMessage>> Drop for SessionManager<I> {
     fn drop(&mut self) {
         if !self.fast_packet.is_empty() {
             let in_flight_sessions: Vec<_> = self.fast_packet.keys().collect();

--- a/src/can/tp.rs
+++ b/src/can/tp.rs
@@ -293,7 +293,7 @@ impl Session for Iso11783TransportProtocolSession {
             let control_byte = frame.data[0];
             match control_byte {
                 // TP.CM_RTS and TP.CM_BAM are src -> dst
-                0x10 | 0x20 => return (src << 8) | dst,
+                0x10 | 0x20 => (src << 8) | dst,
                 // TP.CM_CTS, TP.CM_ABRT, and TP.CM_ACK are dst -> src
                 0x11 | 0x13 | 0xFF => (dst << 8) | src,
                 _ => unreachable!("TP.CM Control byte {control_byte:#X} is reserved"),


### PR DESCRIPTION
Closes #49 