### PR TITLE
csvstats: Output summary statistics in CSV format

### DIFF
--- a/src/bin/csvdelta.rs
+++ b/src/bin/csvdelta.rs
@@ -119,7 +119,7 @@ fn main() -> eyre::Result<()> {
     let header = has_header.then_some(input.headers()?).cloned();
 
     // Find the column index of the input column
-    let column_index = column_index(&mut input, args.column)?;
+    let column_index = column_index(&mut input, &args.column)?;
 
     // Write the new header to the output file
     if let Some(header) = header {
@@ -151,7 +151,12 @@ fn main() -> eyre::Result<()> {
         // be just to read the input file twice, which for very very large files, might be better?
         let records: Vec<_> = records.collect();
         let values = records.iter().flat_map(|(_rec, maybe_value)| maybe_value);
-        let stats = OnlineStats::from_unsorted_iter(values, None, None);
+        let filename = args
+            .input
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or("stdin".to_string());
+        let stats = OnlineStats::from_unsorted_iter(filename, &args.column, values, None, None);
 
         let records = map_column_records(records.into_iter(), |maybe_value| {
             maybe_value.map(|v| v - stats.mean).ok()

--- a/src/bin/csvstats.rs
+++ b/src/bin/csvstats.rs
@@ -122,10 +122,14 @@ fn main() -> eyre::Result<()> {
     let stats_start = Instant::now();
 
     let mut all_stats = Vec::new();
+    println!("{}", OnlineStats::get_csv_header());
     for (colname, col_data) in args.column.iter().zip(&mut data) {
-        let stats = OnlineStats::from_unsorted_mut(col_data, args.min, args.max);
-
-        println!("Stats for column {colname:?}:");
+        let filename = args
+            .input
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or("stdin".to_string());
+        let stats = OnlineStats::from_unsorted_mut(filename, colname, col_data, args.min, args.max);
         println!("{stats}");
 
         all_stats.push(stats);

--- a/tests/test_csvstats.rs
+++ b/tests/test_csvstats.rs
@@ -35,26 +35,9 @@ fn test_csvstats_no_plotting() {
     // The ragged lengths result in 3 NaNs that get filtered out in the second column
 
     let expected = "\
-Stats for column \"rolls-session-1\":
-    count: 24
-    Q1: 3.5
-    median: 10
-    Q3: 13
-    min: 2 at index: 0
-    max: 20 at index: 4
-    mean: 9.791666666666664
-    stddev: 6.93178623865251
-
-Stats for column \"rolls-session-2\":
-    count: 21
-    filtered: 3 (total: 24)
-    Q1: 5
-    median: 8
-    Q3: 14
-    min: 2 at index: 5
-    max: 18 at index: 14
-    mean: 9.571428571428573
-    stddev: 5.803823252952202\n\n\
+        filename,colname,count,filtered,min,min-index,max,max-index,mean,stddev,Q1,median,Q3\n\
+        \"stdin\",\"rolls-session-1\",24,0,2,0,20,4,9.791666666666664,6.93178623865251,3.5,10,13\n\
+        \"stdin\",\"rolls-session-2\",21,3,2,5,18,14,9.571428571428573,5.803823252952202,5,8,14\n\
     ";
 
     let mut cmd = tool("csvstats");


### PR DESCRIPTION
This makes it easier to programatically consume the output of csvstats, as well as aggregating statistics across multiple sets of inputs.